### PR TITLE
Hide menu when greeting is open

### DIFF
--- a/src/nodes/npc.lua
+++ b/src/nodes/npc.lua
@@ -266,11 +266,16 @@ function NPC.new(node, collider)
   
     -- deals with npc walking
     npc.walking = npc.props.walking or false
+    npc.walkingCheck = true
     npc.minx = node.x - (npc.props.max_walk or 48)
     npc.maxx = node.x + (npc.props.max_walk or 48)
     npc.walk_speed = npc.props.walk_speed or 18
     npc.wasWalking = false
     
+    if npc.walking then
+        npc.walkingCheck = true
+    end
+
     npc.run_speed = npc.props.run_speed or 100
 
     -- deals with staring
@@ -399,11 +404,23 @@ function NPC:keypressed( button, player )
         else
             self.direction = "right"
         end
-        if self.greeting and self.db:get( self.name .. '-greeting', true) then
-            self.dialog = Dialog.new(self.greeting)
-            self.db:set( self.name .. '-greeting', false)
+        if self.walkingCheck then
+            self.walking=false
         end
-         self.menu:open(player)
+        if self.greeting and self.db:get( self.name .. '-greeting', true) then
+            self.db:set( self.name .. '-greeting', false)
+            self.dialog = Dialog.new(self.greeting, function()
+                self.menu:open(player)
+                if self.walkingCheck then
+                    self.walking=true
+                end
+                end)
+        else
+            self.menu:open(player)
+            if self.walkingCheck then
+                self.walking=true
+            end
+        end
         if self.begin then self.begin(self, player) end
     else
         return self.menu:keypressed(button, player)


### PR DESCRIPTION
Hides the npc's menu while the greeting dialog is open the first time you meet the npc.
