### PR TITLE
Projectiles breaking blocks

### DIFF
--- a/src/nodes/projectile.lua
+++ b/src/nodes/projectile.lua
@@ -40,7 +40,9 @@ function Projectile.new(node, collider)
   proj.foreground = proj.props.foreground
 
   proj.collider = collider
-  proj.bb = collider:addRectangle(node.x, node.y, proj.props.width, proj.props.height ) -- use properties height to give proper size
+  local bb_width = proj.props.bb_width or proj.props.width
+  local bb_height = proj.props.bb_height or proj.props.height
+  proj.bb = collider:addRectangle(node.x, node.y, bb_width, bb_height ) -- use properties height to give proper size
   proj.bb.node = proj
   proj.start_x = node.x
   proj.explosive = false or proj.props.explosive

--- a/src/nodes/projectiles/arrow.lua
+++ b/src/nodes/projectiles/arrow.lua
@@ -5,6 +5,7 @@ return{
   friction = 1,
   width = 27,
   height = 7,
+  bb_width = 35,
   frameWidth = 27,
   frameHeight = 7,
   solid = true,

--- a/src/nodes/projectiles/icicle.lua
+++ b/src/nodes/projectiles/icicle.lua
@@ -5,6 +5,7 @@ return{
   friction = 1, --0.01 * game.step,
   width = 16,
   height = 16,
+  bb_width = 25,
   frameWidth = 24,
   frameHeight = 24,
   solid = true,

--- a/src/nodes/projectiles/lightning.lua
+++ b/src/nodes/projectiles/lightning.lua
@@ -6,6 +6,7 @@ return{
   friction = 1,
   width = 100,
   height = 30,
+  bb_width = 120,
   frameWidth = 100,
   frameHeight = 30,
   solid = true,

--- a/src/nodes/projectiles/rainbowbeam.lua
+++ b/src/nodes/projectiles/rainbowbeam.lua
@@ -5,6 +5,7 @@ return{
   friction = 1, --0.01 * game.step,
   width = 32,
   height = 26 ,
+  bb_width = 40,
   frameWidth = 32,
   frameHeight = 26,
   solid = true,

--- a/src/nodes/projectiles/throwingaxe.lua
+++ b/src/nodes/projectiles/throwingaxe.lua
@@ -5,6 +5,8 @@ return{
   friction = 0.01 * game.step,
   width = 16,
   height = 16,
+  bb_width = 24,
+  bb_height = 24,
   frameWidth = 24,
   frameHeight = 24,
   solid = true,

--- a/src/nodes/projectiles/throwingknife.lua
+++ b/src/nodes/projectiles/throwingknife.lua
@@ -5,6 +5,7 @@ return{
   friction = 1, --0.01 * game.step,
   width = 16,
   height = 16,
+  bb_width = 25,
   frameWidth = 24,
   frameHeight = 24,
   solid = true,

--- a/src/nodes/projectiles/throwingtorch.lua
+++ b/src/nodes/projectiles/throwingtorch.lua
@@ -5,6 +5,8 @@ return{
   friction = 0.01 * game.step,
   width = 24,
   height = 44,
+  bb_width = 35,
+  bb_height = 50,
   frameWidth = 42,
   frameHeight = 44,
   solid = true,


### PR DESCRIPTION
This is the fix I mentioned in your pull request, it enlarges the bounding box of some of the projectiles so that they collide using the bb system as opposed to the new collision system.